### PR TITLE
Add new Id Registry classes, deprecate old ones

### DIFF
--- a/src/longeron/id_management/bitview_registry.hpp
+++ b/src/longeron/id_management/bitview_registry.hpp
@@ -1,0 +1,120 @@
+/**
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2022 Neal Nicdao <chrisnicdao0@gmail.com>
+ */
+#pragma once
+
+#include "null.hpp"
+
+#include "../containers/bit_view.hpp"
+
+#include "../utility/enum_traits.hpp"
+#include "../utility/asserts.hpp"
+
+namespace lgrn
+{
+
+template<typename BITVIEW_T, typename ID_T>
+class BitViewIdRegistry : private BITVIEW_T
+{
+    using id_int_t = underlying_int_type_t<ID_T>;
+
+public:
+    BitViewIdRegistry() = default;
+    BitViewIdRegistry(BITVIEW_T bitview) : BITVIEW_T(bitview) {};
+    BitViewIdRegistry(BITVIEW_T bitview, [[maybe_unused]] ID_T) : BITVIEW_T(bitview) {};
+
+    /**
+     * @brief Create a single ID
+     *
+     * @return A newly created ID
+     */
+    [[nodiscard]] ID_T create()
+    {
+        ID_T output{ id_null<ID_T>() };
+        create(&output, &output + 1);
+        return output;
+    }
+
+    /**
+     * @brief Create multiple IDs
+     *
+     * @param first [out]
+     * @param last  [in]
+     */
+    template<typename IT_T, typename ITB_T>
+    IT_T create(IT_T first, ITB_T last);
+
+    /**
+     * @return Size required to fit all existing IDs, or allocated size if
+     *         reserved ahead of time
+     */
+    constexpr std::size_t capacity() const noexcept { return BITVIEW_T::size(); }
+
+    /**
+     * @return Number of registered IDs
+     */
+    constexpr std::size_t size() const { return capacity() - BITVIEW_T::count(); }
+
+    /**
+     * @brief Remove an ID. This will mark it for reuse
+     *
+     * @param id [in] ID to remove
+     */
+    void remove(ID_T id)
+    {
+        LGRN_ASSERTMV(exists(id), "ID does not exist", std::size_t(id));
+
+        BITVIEW_T::set(id_int_t(id));
+    }
+
+    /**
+     * @brief Check if an ID exists
+     *
+     * @param id [in] ID to check
+     *
+     * @return true if ID exists
+     */
+    bool exists(ID_T id) const noexcept
+    {
+        return (id_int_t(id) < capacity()) && ( ! BITVIEW_T::test(id_int_t(id)));
+    };
+
+    constexpr BITVIEW_T& bitview() noexcept { return static_cast<BITVIEW_T&>(*this); }
+    constexpr BITVIEW_T const& bitview() const noexcept { return static_cast<BITVIEW_T const&>(*this); }
+};
+
+template<typename BITVIEW_T, typename ID_T>
+template<typename IT_T, typename ITB_T>
+IT_T BitViewIdRegistry<BITVIEW_T, ID_T>::create(IT_T first, ITB_T last)
+{
+    auto ones = BITVIEW_T::ones();
+    auto onesFirst = std::begin(ones);
+    auto onesLast = std::end(ones);
+
+    while ( (first != last) && (onesFirst != onesLast) )
+    {
+        std::size_t const pos = *onesFirst;
+        *first = ID_T(pos);
+
+        BITVIEW_T::reset(pos);
+
+        std::advance(onesFirst, 1);
+        std::advance(first, 1);
+    }
+    return first;
+}
+
+template <typename IT_T, typename ITB_T, typename ID_T>
+constexpr auto bitview_id_reg(IT_T first, ITB_T last, [[maybe_unused]] ID_T id)
+{
+    return BitViewIdRegistry(lgrn::bit_view(first, last), id);
+}
+
+template <typename RANGE_T, typename ID_T>
+constexpr auto bitview_id_reg(RANGE_T& rRange, [[maybe_unused]] ID_T id = ID_T(0))
+{
+    return bitview_id_reg(std::begin(rRange), std::end(rRange), ID_T(0));
+}
+
+} // namespace lgrn

--- a/src/longeron/id_management/registry.hpp
+++ b/src/longeron/id_management/registry.hpp
@@ -14,6 +14,8 @@ namespace lgrn
 
 /**
  * @brief Generates reusable sequential IDs
+ *
+ * @deprecated use IdRegistryStl
  */
 template<typename ID_T, bool NO_AUTO_RESIZE = false>
 class IdRegistry

--- a/src/longeron/id_management/registry_stl.hpp
+++ b/src/longeron/id_management/registry_stl.hpp
@@ -1,0 +1,104 @@
+/**
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2022 Neal Nicdao <chrisnicdao0@gmail.com>
+ */
+#pragma once
+
+
+#include "bitview_registry.hpp"
+#include "../containers/bit_view.hpp"
+
+
+#include <vector>
+
+namespace lgrn
+{
+
+
+/**
+ * @brief STL-style owning IdRegistry with underlying std::vector
+ */
+template<typename ID_T, bool NO_AUTO_RESIZE = false,
+         typename BITVIEW_T = BitView< std::vector<uint64_t> > >
+class IdRegistryStl : private BitViewIdRegistry<BITVIEW_T, ID_T>
+{
+    using underlying_t = BitViewIdRegistry<BITVIEW_T, ID_T>;
+
+    friend underlying_t;
+
+public:
+
+    IdRegistryStl() = default;
+    IdRegistryStl(underlying_t reg) : underlying_t(reg) { }
+
+    using underlying_t::size;
+    using underlying_t::remove;
+    using underlying_t::exists;
+
+    /**
+     * @brief Create a single ID
+     *
+     * @return A newly created ID
+     */
+    [[nodiscard]] ID_T create()
+    {
+        ID_T output{ id_null<ID_T>() };
+        create(&output, &output + 1);
+        return output;
+    }
+
+    /**
+     * @brief Create multiple IDs
+     *
+     * @param first [out]
+     * @param last  [in]
+     */
+    template<typename IT_T, typename ITB_T>
+    IT_T create(IT_T first, ITB_T last);
+
+    void reserve(std::size_t n)
+    {
+        // may need some considerations when hierarchical bitsets are re-added
+        vec().resize(n / underlying_t::bitview().int_bitsize() + 1, uint64_t());
+    }
+
+    auto& vec() noexcept { return underlying_t::bitview().ints(); }
+    auto const& vec() const noexcept { return underlying_t::bitview().ints(); }
+};
+
+
+template<typename ID_T, bool NO_AUTO_RESIZE, typename BITVIEW_T>
+template<typename IT_T, typename ITB_T>
+IT_T IdRegistryStl<ID_T, NO_AUTO_RESIZE, BITVIEW_T>::create(IT_T first, ITB_T last)
+{
+    if constexpr (NO_AUTO_RESIZE)
+    {
+        return underlying_t::create(first, last);
+    }
+    else
+    {
+        while (true)
+        {
+            first = underlying_t::create(first, last);
+
+            if (first != last) [[unlikely]]
+            {
+                // out of space, not all IDs were created
+
+                // initialize to all bits set, as ones are for free IDs
+                // semi-jank way to use vector's automatic reallocation logic
+                vec().push_back(~uint64_t(0));
+                vec().resize(vec().capacity(), ~uint64_t(0));
+
+            }
+            else [[likely]]
+            {
+                break;
+            }
+        }
+        return first;
+    }
+}
+
+
+} // namespace lgrn

--- a/test/id_management/registry.cpp
+++ b/test/id_management/registry.cpp
@@ -2,10 +2,11 @@
  * SPDX-License-Identifier: MIT
  * SPDX-FileCopyrightText: 2021 Neal Nicdao <chrisnicdao0@gmail.com>
  */
-#include <longeron/id_management/registry.hpp>
+#include <longeron/id_management/registry_stl.hpp>
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <random>
 
 enum class Id : uint64_t { };
@@ -17,7 +18,7 @@ static_assert(std::is_same_v<lgrn::underlying_int_type_t<Id>, uint64_t>);
 // Basic intended use test of managing IDs
 TEST(IdRegistry, ManageIds)
 {
-    lgrn::IdRegistry<Id> registry;
+    lgrn::IdRegistryStl<Id> registry;
 
     Id idA = registry.create();
     Id idB = registry.create();
@@ -42,7 +43,7 @@ TEST(IdRegistry, ManageIds)
     EXPECT_EQ( registry.size(), 2 );
 
     std::array<Id, 32> ids;
-    registry.create(std::begin(ids), ids.size());
+    registry.create(std::begin(ids), std::end(ids));
 
     for (Id id : ids)
     {
@@ -61,7 +62,7 @@ TEST(IdRegistry, RandomCreationAndDeletion)
     constexpr size_t const sc_createMin = 60;
     constexpr size_t const sc_repetitions = 32;
 
-    lgrn::IdRegistry<Id> registry;
+    lgrn::IdRegistryStl<Id> registry;
 
     std::set<Id> idSet;
 
@@ -70,14 +71,14 @@ TEST(IdRegistry, RandomCreationAndDeletion)
     std::uniform_int_distribution<int> distFlip(0, 1);
 
 
-    for (int i = 0; i < sc_repetitions; i ++)
+    for (unsigned int i = 0; i < sc_repetitions; i ++)
     {
         // Create a bunch of new IDs
 
         size_t const toCreate = distCreate(gen);
         std::array<Id, sc_createMax> newIds;
 
-        registry.create(std::begin(newIds), toCreate);
+        registry.create(std::begin(newIds), std::begin(newIds) + toCreate);
         idSet.insert(std::begin(newIds), std::begin(newIds) + toCreate);
 
         // Remove about half of the IDs


### PR DESCRIPTION
Addressing #5, the new id registries are mixins (or adaptors?) over a bit view, which itself is also a mixin/adaptor over an integer range. This effectively makes storage options extremely flexible.

An owning STL-style registry is now provided by IdRegistryStl.