### PR TITLE
Expose C++20 as a requirement for consumers of longeron

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,9 @@ cmake_minimum_required(VERSION 3.12)
 
 project(longeron VERSION 0.1.0)
 
-set(CMAKE_CXX_STANDARD 17)
-
 add_library(longeron INTERFACE)
+
+target_compile_features(longeron INTERFACE cxx_std_20)
 
 target_include_directories(longeron INTERFACE src)
 


### PR DESCRIPTION
```
D:\a\osp-magnum\osp-magnum\src\osp\Resource\resources.h(205): message : see reference to class template instantiation 'lgrn::IdRegistry<osp::PkgId,false>' being compiled [D:\a\osp-magnum\osp-magnum\build\test\resources\test_resources.vcxproj]
D:\a\osp-magnum\osp-magnum\3rdparty\longeronpp\src\longeron/id_management/refcount.hpp(41,9): warning C5051: attribute 'unlikely' requires at least '/std:c++20'; ignored [D:\a\osp-magnum\osp-magnum\build\test\resources\test_resources.vcxproj]
```